### PR TITLE
Change `baseline` default of `prediction_breakdown()` to be consistent with `broken()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 DALEX 0.2.5
 ----------------------------------------------------------------
-* You can now change the `baseline` argument in the `broken.default()`function, which is called by the `single_prediction()` function. ([#39](https://github.com/pbiecek/DALEX/issues/39))
+* The defaults of `single_prediction()` are now consistent with `breakDown::broken()`. Specifically, `baseline` is now `0` by default instead of `"Intercept"`. The user can also specify the `baseline` and other arguments by passing them to `single_prediction`. ([#39](https://github.com/pbiecek/DALEX/issues/39))
 
 
 DALEX 0.2.4

--- a/R/single_prediction.R
+++ b/R/single_prediction.R
@@ -3,7 +3,6 @@
 #' @param explainer a model to be explained, preprocessed by the 'explain' function
 #' @param observation a new observarvation for which predictions need to be explained
 #' @param ... other parameters that will be passed to \code{breakDown::broken.default()}
-#' @param baseline this argument will be passed to \code{breakDown::broke.default()}, by default it's \code{"Intercept"}
 #'
 #' @return An object of the class 'single_prediction_explainer'.
 #' It's a data frame with calculated average response.
@@ -54,7 +53,7 @@
 #'  plot(exp_sgn)
 #'  }
 #'
-prediction_breakdown <- function(explainer, observation, ..., baseline = "Intercept") {
+prediction_breakdown <- function(explainer, observation, ...) {
   if (!("explainer" %in% class(explainer))) stop("The prediction_breakdown() function requires an object created with explain() function.")
   if (is.null(explainer$data)) stop("The prediction_breakdown() function requires explainers created with specified 'data' parameter.")
 
@@ -63,7 +62,7 @@ prediction_breakdown <- function(explainer, observation, ..., baseline = "Interc
                 new_observation = observation,
                 data = explainer$data,
                 predict.function = explainer$predict_function,
-                baseline = baseline, ...)
+                ...)
   res$label <- rep(explainer$label, length(res$variable))
 
   class(res) <- c("prediction_breakdown_explainer", "data.frame")

--- a/man/prediction_breakdown.Rd
+++ b/man/prediction_breakdown.Rd
@@ -5,7 +5,7 @@
 \alias{single_prediction}
 \title{Explanations for a Single Prediction}
 \usage{
-prediction_breakdown(explainer, observation, ..., baseline = "Intercept")
+prediction_breakdown(explainer, observation, ...)
 }
 \arguments{
 \item{explainer}{a model to be explained, preprocessed by the 'explain' function}
@@ -13,8 +13,6 @@ prediction_breakdown(explainer, observation, ..., baseline = "Intercept")
 \item{observation}{a new observarvation for which predictions need to be explained}
 
 \item{...}{other parameters that will be passed to \code{breakDown::broken.default()}}
-
-\item{baseline}{this argument will be passed to \code{breakDown::broke.default()}, by default it's \code{"Intercept"}}
 }
 \value{
 An object of the class 'single_prediction_explainer'.
@@ -60,6 +58,9 @@ model <- gbm(quality ~ pH + residual.sugar + sulphates + alcohol, data = wine,
  # create a new observation
  exp_sgn <- prediction_breakdown(explainer_gbm, observation = new.wine)
  exp_sgn
+ plot(exp_sgn)
+
+ exp_sgn <- prediction_breakdown(explainer_gbm, observation = new.wine, baseline = 0)
  plot(exp_sgn)
  }
 

--- a/tests/testthat/test_prediction_breakdown.R
+++ b/tests/testthat/test_prediction_breakdown.R
@@ -12,3 +12,18 @@ test_that("Output format - plot",{
   expect_is(plot(pb_rf, pb_lm), "gg")
 })
 
+test_that("Default parameters agree with broken() (#39)", {
+  expect_identical(
+    attr(breakDown::broken(explainer_regr_lm$model, new_apartments), "baseline"),
+    attr(pb_lm, "baseline")
+  )
+
+  rf_breakdown <- breakDown::broken(
+    explainer_regr_rf$model, new_apartments,
+    data = explainer_regr_rf$data, predict.function = explainer_regr_rf$predict_function
+  )
+  expect_identical(
+    attr(rf_breakdown, "baseline"),
+    attr(pb_rf, "baseline")
+  )
+})

--- a/tests/testthat/test_prediction_breakdown.R
+++ b/tests/testthat/test_prediction_breakdown.R
@@ -27,3 +27,25 @@ test_that("Default parameters agree with broken() (#39)", {
     attr(pb_rf, "baseline")
   )
 })
+
+test_that("`baseline` argument is respected when specified (#39)", {
+  pb_lm_baseline_intercept <- prediction_breakdown(explainer_regr_lm, observation = new_apartments, baseline = "Intercept")
+  breakdown_lm_baseline_intercept <- breakDown::broken(explainer_regr_lm$model, new_apartments, baseline = "Intercept")
+
+  pb_rf_baseline_intercept <- prediction_breakdown(explainer_regr_rf, observation = new_apartments, baseline = "Intercept")
+  breakdown_rf_baseline_intercept <- breakDown::broken(
+    explainer_regr_rf$model, new_apartments,
+    data = explainer_regr_rf$data, predict.function = explainer_regr_rf$predict_function,
+    baseline = "Intercept"
+  )
+
+  expect_identical(
+    attr(pb_lm_baseline_intercept, "baseline"),
+    attr(breakdown_lm_baseline_intercept, "baseline")
+  )
+
+  expect_identical(
+    attr(pb_rf_baseline_intercept, "baseline"),
+    attr(breakdown_rf_baseline_intercept, "baseline")
+  )
+})


### PR DESCRIPTION
This change:
- Removes the default of the `baseline` parameter of `prediction_breakdown()`. This is so that the defaults agree with the underlying `breakDown::broken()` function. This is a *potentially* breaking if users were depending on the hardcoded `baseline = "Intercept"`, but I'd argue consistency with `broken()` should be the expected behavior.

Closes #39 