### PR TITLE
Improve model performance residual distribution plotting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 DALEX 0.2.5
 ----------------------------------------------------------------
-* The defaults of `single_prediction()` are now consistent with `breakDown::broken()`. Specifically, `baseline` is now `0` by default instead of `"Intercept"`. The user can also specify the `baseline` and other arguments by passing them to `single_prediction`. ([#39](https://github.com/pbiecek/DALEX/issues/39)) WARNING: Change in the default value of `baseline`.
+* Residual distribution plots for model performance are now more legible when multiple models are plotted. The styling of plot and axis titles have also been improved (@kevinykuo).
+
+* The defaults of `single_prediction()` are now consistent with `breakDown::broken()`. Specifically, `baseline` is now `0` by default instead of `"Intercept"`. The user can also specify the `baseline` and other arguments by passing them to `single_prediction` (@kevinykuo, [#39](https://github.com/pbiecek/DALEX/issues/39)). **WARNING:** Change in the default value of `baseline`.
+
 * New `yhat.*` functions help to handle additional parameters to different `predict()` functions.
 
 DALEX 0.2.4

--- a/R/plot_model_performance.R
+++ b/R/plot_model_performance.R
@@ -60,7 +60,6 @@ plot.model_performance_explainer <- function(x, ..., geom = "ecdf", show_outlier
   if (geom == "ecdf") {
     pl <-   ggplot(df, aes(abs(diff), color = label)) +
       stat_ecdf(geom = "step") +
-      stat_ecdf(geom = "point") +
       theme_mi2() +
       scale_color_brewer(name = "Model", type = "qual", palette = "Dark2") +
       xlab("| residuals |") +

--- a/R/plot_model_performance.R
+++ b/R/plot_model_performance.R
@@ -62,12 +62,12 @@ plot.model_performance_explainer <- function(x, ..., geom = "ecdf", show_outlier
       stat_ecdf(geom = "step") +
       theme_mi2() +
       scale_color_brewer(name = "Model", type = "qual", palette = "Dark2") +
-      xlab("| residuals |") +
+      xlab(expression(paste("|", residual, "|"))) +
       scale_y_continuous(breaks = seq(0,1,0.1),
                          labels = paste(seq(100,0,-10),"%"),
                          trans = "reverse",
                          name = "") +
-      ggtitle("Distribution of | residuals |")
+      ggtitle(expression(paste("Distribution of |", residual, "|")))
   } else {
     pl <- ggplot(df, aes(x=label, y=abs(diff), fill = label)) +
       stat_boxplot(alpha=0.4, coef = 1000) +

--- a/R/plot_model_performance.R
+++ b/R/plot_model_performance.R
@@ -40,7 +40,7 @@ plot.model_performance_explainer <- function(x, ..., geom = "ecdf", show_outlier
   if (!(ptlabel %in% c("name", "index"))){
     stop("The plot.model_performance() function requires label to be name or index.")
   }
-   df <- x
+  df <- x
   class(df) <- "data.frame"
   df$name <- seq.int(nrow(df))
   dfl <- list(...)
@@ -75,7 +75,10 @@ plot.model_performance_explainer <- function(x, ..., geom = "ecdf", show_outlier
       theme_mi2() +
       scale_fill_brewer(name = "Model", type = "qual", palette = "Dark2") +
       ylab("") + xlab("") +
-      ggtitle("Boxplots of | residuals |", "Red dot stands for root mean square of residuals") +
+      ggtitle(
+        expression(paste("Boxplots of |", residual, "|")),
+        "Red dot stands for root mean square of residuals"
+      ) +
       coord_flip()
     if (show_outliers > 0) {
       df$rank <- unlist(tapply(-abs(df$diff), df$label, rank, ties.method = "min"))

--- a/R/plot_model_performance.R
+++ b/R/plot_model_performance.R
@@ -62,12 +62,12 @@ plot.model_performance_explainer <- function(x, ..., geom = "ecdf", show_outlier
       stat_ecdf(geom = "step") +
       theme_mi2() +
       scale_color_brewer(name = "Model", type = "qual", palette = "Dark2") +
-      xlab(expression(paste("|", residual, "|"))) +
+      xlab(expression(group("|", residual, "|"))) +
       scale_y_continuous(breaks = seq(0,1,0.1),
                          labels = paste(seq(100,0,-10),"%"),
                          trans = "reverse",
                          name = "") +
-      ggtitle(expression(paste("Distribution of |", residual, "|")))
+      ggtitle(expression(paste("Distribution of ", group("|", residual, "|"))))
   } else {
     pl <- ggplot(df, aes(x=label, y=abs(diff), fill = label)) +
       stat_boxplot(alpha=0.4, coef = 1000) +
@@ -76,7 +76,7 @@ plot.model_performance_explainer <- function(x, ..., geom = "ecdf", show_outlier
       scale_fill_brewer(name = "Model", type = "qual", palette = "Dark2") +
       ylab("") + xlab("") +
       ggtitle(
-        expression(paste("Boxplots of |", residual, "|")),
+        expression(paste("Boxplots of", group("|", residual, "|"))),
         "Red dot stands for root mean square of residuals"
       ) +
       coord_flip()

--- a/R/plot_model_performance.R
+++ b/R/plot_model_performance.R
@@ -76,7 +76,7 @@ plot.model_performance_explainer <- function(x, ..., geom = "ecdf", show_outlier
       scale_fill_brewer(name = "Model", type = "qual", palette = "Dark2") +
       ylab("") + xlab("") +
       ggtitle(
-        expression(paste("Boxplots of", group("|", residual, "|"))),
+        expression(paste("Boxplots of ", group("|", residual, "|"))),
         "Red dot stands for root mean square of residuals"
       ) +
       coord_flip()


### PR DESCRIPTION
This change
- Makes the lines thinner in the residual distribution model performance plots so they are more legible when multiple models are plotted.
- Uses latex for axis and plot titles so `|residual|` looks more elegant.

Example with the change:

![image](https://user-images.githubusercontent.com/5582151/46849785-08297500-cda6-11e8-9362-55c3d376f53c.png)
